### PR TITLE
Feature to validate certificate for a SSL connection

### DIFF
--- a/src/main/groovy/no/tornado/fxlauncher/gradle/FXLauncherExtension.groovy
+++ b/src/main/groovy/no/tornado/fxlauncher/gradle/FXLauncherExtension.groovy
@@ -44,6 +44,8 @@ class FXLauncherExtension {
 
     String cacheDir
 
+    String certDigest
+
     Boolean acceptDowngrade
 
     Boolean lingeringUpdateScreen = false

--- a/src/main/groovy/no/tornado/fxlauncher/gradle/GenerateApplicationManifestTask.groovy
+++ b/src/main/groovy/no/tornado/fxlauncher/gradle/GenerateApplicationManifestTask.groovy
@@ -49,6 +49,9 @@ class GenerateApplicationManifestTask extends DefaultTask {
         if (fxlauncher.acceptDowngrade)
             args += '--accept-downgrade=' + fxlauncher.acceptDowngrade
 
+        if (fxlauncher.certDigest)
+            args += '--cert-digest=' + fxlauncher.certDigest
+
         args += '--lingering-update-screen=' + fxlauncher.lingeringUpdateScreen
 
         def appParams = fxlauncher.resolveApplicationParameters()


### PR DESCRIPTION
Custom TrustManager for validating cert digest
Linked to:
https://github.com/edvin/fxldemo-gradle/issues/8

Added new param certDigest .. same as that of cacheDir