### PR TITLE
Add inheritIO() method call to GenerateNativeInstallerTask's ProcessBuilder

### DIFF
--- a/src/main/groovy/no/tornado/fxlauncher/gradle/GenerateNativeInstallerTask.groovy
+++ b/src/main/groovy/no/tornado/fxlauncher/gradle/GenerateNativeInstallerTask.groovy
@@ -30,7 +30,7 @@ class GenerateNativeInstallerTask extends DefaultTask {
 
         if (fxlauncher.javapackagerOptions) params.addAll(fxlauncher.javapackagerOptions)
 
-        def status = new ProcessBuilder(params).start().waitFor()
+        def status = new ProcessBuilder(params).inheritIO().start().waitFor()
 
         if (status != 0)
             throw new GradleException('javapackager exited with status ' + status)


### PR DESCRIPTION
The subprocesses that are created by ProcessBuilder write standard error and standard output to pipes. Because of that, the -v flag passed to the javapackager option outputs nothing to the console. That makes it impossible for the user to follow section [7.3.3.1 Preparing Custom Resources](https://docs.oracle.com/javase/8/docs/technotes/guides/deploy/self-contained-packaging.html#JSDPG606) of the javapackager documentation because the temporary location where the default application configuration files and resources are saved is lost. By chaining the inheritIO() method call to the ProcessBuilder invocation the javapackager subprocess standard I/O will be the same as those of the current Java process and the -v flag should work properly.