### PR TITLE
Include artifact classifiers when copying dependencies

### DIFF
--- a/src/main/groovy/no/tornado/fxlauncher/gradle/CopyAppDependenciesTask.groovy
+++ b/src/main/groovy/no/tornado/fxlauncher/gradle/CopyAppDependenciesTask.groovy
@@ -30,7 +30,11 @@ public class CopyAppDependenciesTask extends DefaultTask {
             project.copy {
                 from artifact.file
                 into workingDirectory
-                rename { "${artifact.name}.${artifact.extension}" }
+                if (artifact.classifier != null) {
+                    rename { "${artifact.name}-${artifact.classifier}.${artifact.extension}" }
+                } else {
+                    rename { "${artifact.name}.${artifact.extension}" }
+                }
             }
         }
         project.copy {


### PR DESCRIPTION
I'm using [JavaCV](https://github.com/bytedeco/javacv) in my JavaFX project, which consists of a couple of dependencies. I had a problem with `CopyAppDependenciesTask` where it [renames](https://github.com/edvin/fxlauncher-gradle-plugin/blob/master/src/main/groovy/no/tornado/fxlauncher/gradle/CopyAppDependenciesTask.groovy#L33) libraries and in my case overwrites them. Calling `copyAppDependencies` ended up with a single `opencv.jar`. I've modified the task to include 
the classifier, if there's any.

E.g.:

| name | classifier | extension | result |
|---|---|---|---|
| opencv | null | jar | opencv.jar |
| opencv | android-arm | jar | opencv-android-arm.jar |
| opencv | macosx-x86_64 | jar | opencv-macosx-x86_64.jar |