### PR TITLE
Update in order to complete UNC support

### DIFF
--- a/src/main/groovy/no/tornado/fxlauncher/gradle/FXLauncherExtension.groovy
+++ b/src/main/groovy/no/tornado/fxlauncher/gradle/FXLauncherExtension.groovy
@@ -24,7 +24,7 @@ import org.gradle.api.Project
  */
 @CompileStatic
 class FXLauncherExtension {
-    String fxlauncherVersion = '1.0.17'
+    String fxlauncherVersion = '1.0.21'
 
     String applicationMainClass
 


### PR DESCRIPTION
It looks as if the original project fxlauncher had all the updates it needed, but then the plugin version was still using version 1.0.17 of fxlauncher and so would not have implemented the necessary changes.